### PR TITLE
Add youtube-transcript-api package and new endpoint

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,7 +1,16 @@
 from fastapi import FastAPI
+from youtube_transcript_api import YouTubeTranscriptApi
 
 app = FastAPI()
 
 @app.get("/")
 async def root():
     return {"greeting": "Hello, World!", "message": "Welcome to FastAPI!"}
+
+@app.get("/transcript/{video_id}")
+async def get_transcript(video_id: str):
+    try:
+        transcript = YouTubeTranscriptApi.get_transcript(video_id)
+        return {"transcript": transcript}
+    except Exception as e:
+        return {"error": str(e)}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 fastapi==0.100.0
 hypercorn==0.14.4
+youtube-transcript-api


### PR DESCRIPTION
Add functionality to fetch YouTube video transcripts using `youtube-transcript-api`.

* **requirements.txt**
  - Add `youtube-transcript-api` to the list of dependencies.

* **main.py**
  - Import `YouTubeTranscriptApi` from `youtube_transcript_api`.
  - Add a new endpoint `/transcript/{video_id}` to fetch YouTube transcripts.
  - Use `YouTubeTranscriptApi.get_transcript(video_id)` to fetch the transcript.
  - Handle exceptions and return error messages if fetching the transcript fails.

