### PR TITLE
Fix CORS policy issue

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,7 +1,16 @@
 from fastapi import FastAPI
 from youtube_transcript_api import YouTubeTranscriptApi
+from fastapi.middleware.cors import CORSMiddleware
 
 app = FastAPI()
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 
 @app.get("/")
 async def root():

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 fastapi==0.100.0
 hypercorn==0.14.4
 youtube-transcript-api
+fastapi.middleware.cors


### PR DESCRIPTION
Add CORS middleware to FastAPI application to resolve CORS policy issue.

* **main.py**
  - Import `CORSMiddleware` from `fastapi.middleware.cors`.
  - Add CORS middleware to the FastAPI app.
  - Allow all origins, methods, and headers in CORS configuration.

* **requirements.txt**
  - Add `fastapi.middleware.cors` to the list of dependencies.

